### PR TITLE
fix: prevent overwriting existing environment variables

### DIFF
--- a/src/Framework/Config/Env.php
+++ b/src/Framework/Config/Env.php
@@ -45,8 +45,14 @@ class Env
 
                 self::$cache[$key] = $value;
                 putenv("{$key}=" . (is_bool($value) ? ($value ? 'true' : 'false') : (string) $value));
-                $_ENV[$key] = $value;
-                $_SERVER[$key] = $value;
+
+                if(!isset($_ENV[$key])) {
+                    $_ENV[$key] = $value;
+                }
+                
+                if(!isset($_SERVER[$key])) {
+                    $_SERVER[$key] = $value;
+                }
             }
         }
     }


### PR DESCRIPTION
- Added checks to only set $_ENV and $_SERVER values if keys don't already exist
- Preserves existing environment variables that may have been set elsewhere in the application
- Maintains backwards compatibility while improving safety of environment variable handling