### PR TITLE
feat: enhance test environment with default IP address

### DIFF
--- a/src/Framework/Testing/TestCase.php
+++ b/src/Framework/Testing/TestCase.php
@@ -70,6 +70,7 @@ class TestCase extends BaseTestCase
             $_GET = $queryParams; 
         }
 
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['SERVER_PORT'] = '80';
         $_SERVER['HTTPS'] = 'off';


### PR DESCRIPTION
- Added default REMOTE_ADDR (127.0.0.1) to $_SERVER superglobal for test cases
- Ensures consistent IP address simulation in HTTP request testing scenarios
- Complements existing test environment settings for host, port and HTTPS status