### PR TITLE
refactor: standardize environment variable access with get_env()

### DIFF
--- a/src/Framework/Console/Views/Config/AiView.php
+++ b/src/Framework/Console/Views/Config/AiView.php
@@ -30,12 +30,12 @@ return [
                 'version' => get_env('ANTHROPIC_VERSION', '2023-06-01'),
             ],
             'mistral' => [
-                'key' => getenv('MISTRAL_KEY'),
+                'key' => get_env('MISTRAL_KEY'),
                 'model' => 'mistral-small-latest', // Or 'mistral-small', 'mistral-large'
                 'endpoint' => 'https://api.mistral.ai/v1/chat/completions',
             ],
             'groq' => [
-                'key' => getenv('GROQ_KEY'),
+                'key' => get_env('GROQ_KEY'),
                 'model' => 'llama3-70b-8192', // Or 'llama3-8b-8192', 'mixtral-8x7b-32768', etc.
                 'endpoint' => 'https://api.groq.com/openai/v1/chat/completions',
             ],

--- a/tests/Integration/ResendIntegrationTest.php
+++ b/tests/Integration/ResendIntegrationTest.php
@@ -29,7 +29,7 @@ class ResendIntegrationTest extends TestCase
         parent::setUp();
         
         // Skip if Resend not configured
-        if (!getenv('RESEND_API_KEY')) {
+        if (!get_env('RESEND_API_KEY')) {
             $this->markTestSkipped('Resend API key not configured. Set RESEND_API_KEY environment variable.');
         }
         

--- a/tests/Integration/SmtpIntegrationTest.php
+++ b/tests/Integration/SmtpIntegrationTest.php
@@ -30,15 +30,15 @@ class SmtpIntegrationTest extends TestCase
         parent::setUp();
         
         // Skip if Mailtrap credentials not configured
-        if (!getenv('MAILTRAP_HOST')) {
+        if (!get_env('MAILTRAP_HOST')) {
             $this->markTestSkipped('Mailtrap credentials not configured. Set MAILTRAP_* environment variables.');
         }
         
         // Configure SMTP with Mailtrap
-        putenv('MAIL_HOST=' . getenv('MAILTRAP_HOST'));
-        putenv('MAIL_PORT=' . getenv('MAILTRAP_PORT'));
-        putenv('MAIL_USERNAME=' . getenv('MAILTRAP_USERNAME'));
-        putenv('MAIL_PASSWORD=' . getenv('MAILTRAP_PASSWORD'));
+        putenv('MAIL_HOST=' . get_env('MAILTRAP_HOST'));
+        putenv('MAIL_PORT=' . get_env('MAILTRAP_PORT'));
+        putenv('MAIL_USERNAME=' . get_env('MAILTRAP_USERNAME'));
+        putenv('MAIL_PASSWORD=' . get_env('MAILTRAP_PASSWORD'));
         putenv('MAIL_ENCRYPTION=tls');
         putenv('MAIL_FROM_ADDRESS=test@example.com');
         putenv('MAIL_FROM_NAME=Integration Test');

--- a/tests/Storage/S3StorageIntegrationTest.php
+++ b/tests/Storage/S3StorageIntegrationTest.php
@@ -33,9 +33,9 @@ class S3StorageIntegrationTest extends TestCase
         parent::setUp();
         
         // Skip tests if AWS credentials are not set
-        $key = getenv('AWS_ACCESS_KEY');
-        $secret = getenv('AWS_SECRET_KEY');
-        $this->bucket = getenv('AWS_BUCKET');
+        $key = get_env('AWS_ACCESS_KEY');
+        $secret = get_env('AWS_SECRET_KEY');
+        $this->bucket = get_env('AWS_BUCKET');
         
         if (empty($key) || empty($secret) || empty($this->bucket)) {
             $this->markTestSkipped(
@@ -43,7 +43,7 @@ class S3StorageIntegrationTest extends TestCase
             );
         }
         
-        $region = getenv('AWS_REGION') ?: 'us-east-1';
+        $region = get_env('AWS_REGION') ?: 'us-east-1';
         
         // Create S3 client
         $this->s3Client = new S3Client([


### PR DESCRIPTION
- Replaced getenv() calls with get_env() helper function across config and test files for consistent environment variable handling
- Updated AI provider configs (Mistral, Groq) to use get_env()
- Modified integration tests for Resend, SMTP/Mailtrap, and S3 to use get_env()
- Ensures uniform environment variable access pattern throughout the codebase