### PR TITLE
feat: add support for custom database seeders

### DIFF
--- a/src/Framework/Console/Commands/SeedCommand.php
+++ b/src/Framework/Console/Commands/SeedCommand.php
@@ -11,14 +11,41 @@ class SeedCommand implements ICommand
     {
         fputs(STDOUT, "\n");
 
-        if (in_array('--force', $arguments)) {
+        // Extract class name and flags
+        $className = null;
+        $force = false;
+        
+        foreach ($arguments as $arg) {
+            if ($arg === '--force') {
+                $force = true;
+            } elseif (!str_starts_with($arg, '--')) {
+                $className = $arg;
+            }
+        }
+
+        // Default to DatabaseSeeder if no class specified
+        if (!$className) {
+            $className = 'DatabaseSeeder';
+        }
+
+        // Build fully qualified class name
+        $fullyQualifiedClass = "Database\\Seeders\\{$className}";
+
+        // Check if class exists
+        if (!class_exists($fullyQualifiedClass)) {
+            fputs(STDOUT, "✖ Seeder class '{$fullyQualifiedClass}' not found\n\n");
+            return;
+        }
+
+        if ($force) {
             $confirm = 'y';
         } else {
             $confirm = readline('Are you sure you want to continue? (y/n) ');
         }
 
         if(strtolower($confirm) === 'y') {
-            (new DatabaseSeeder)->seed();
+            (new $fullyQualifiedClass)->seed();
+            fputs(STDOUT, "\n✔ Seeded: {$className}\n\n");
         } else {
             fputs(STDOUT, "\n✔ Database seeding cancelled\n\n");
         }


### PR DESCRIPTION
- Added ability to specify custom seeder class as command argument instead of only using DatabaseSeeder
- Improved error handling by checking if specified seeder class exists before execution
- Added success message showing which seeder class was executed
- Refactored argument parsing to separately handle --force flag and class name
- Maintained backwards compatibility by defaulting to DatabaseSeeder when no class specified