### PR TITLE
feat: disable default AI response caching and add endpoint override

### DIFF
--- a/src/Framework/AI/Providers/Anthropic.php
+++ b/src/Framework/AI/Providers/Anthropic.php
@@ -8,7 +8,7 @@ class Anthropic extends AI
     public function generate(array $params)
     {
         $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
-        $useCache = $params['cache'] ?? true;
+        $useCache = $params['cache'] ?? false;
         $cacheTtl = $params['cache_ttl'] ?? $this->config->get('ai.cache_ttl');
         $cacheKey = $this->generateCacheKey($params);
 
@@ -17,8 +17,9 @@ class Anthropic extends AI
             return $this->cache->get($cacheKey);
         }
 
+        $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.anthropic.endpoint');
         $result = $this->makeApiRequest(
-            $this->config->get('ai.providers.anthropic.endpoint'),
+            $endpoint,
             $this->prepareRequestBody($params),
             $this->prepareHeaders(),
             $this->config->get('ai.http_timeout', 10)

--- a/src/Framework/AI/Providers/Groq.php
+++ b/src/Framework/AI/Providers/Groq.php
@@ -11,7 +11,7 @@ class Groq extends AI
     public function generate(array $params): array
     {
         $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
-        $useCache = $params['cache'] ?? true;
+        $useCache = $params['cache'] ?? false;
         $cacheTtl = $params['cache_ttl'] ?? $this->config->get('ai.cache_ttl');
         $cacheKey = $this->generateCacheKey($params);
 
@@ -20,8 +20,9 @@ class Groq extends AI
             return $this->cache->get($cacheKey);
         }
 
+        $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.groq.endpoint');
         $result = $this->makeApiRequest(
-            $this->config->get('ai.providers.groq.endpoint'),
+            $endpoint,
             $this->prepareRequestBody($params),
             $this->prepareHeaders(),
             $this->config->get('ai.http_timeout')

--- a/src/Framework/AI/Providers/Mistral.php
+++ b/src/Framework/AI/Providers/Mistral.php
@@ -11,7 +11,7 @@ class Mistral extends AI
     public function generate(array $params): array
     {
         $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
-        $useCache = $params['cache'] ?? true;
+        $useCache = $params['cache'] ?? false;
         $cacheTtl = $params['cache_ttl'] ?? $this->config->get('ai.cache_ttl',);
         $cacheKey = $this->generateCacheKey($params);
 
@@ -20,8 +20,9 @@ class Mistral extends AI
             return $this->cache->get($cacheKey);
         }
 
+        $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.mistral.endpoint');
         $result = $this->makeApiRequest(
-            $this->config->get('ai.providers.mistral.endpoint'),
+            $endpoint,
             $this->prepareRequestBody($params),
             $this->prepareHeaders(),
             $this->config->get('ai.http_timeout')

--- a/src/Framework/AI/Providers/OpenAI.php
+++ b/src/Framework/AI/Providers/OpenAI.php
@@ -8,7 +8,7 @@ class OpenAI extends AI
     public function generate(array $params)
     {
         $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
-        $useCache = $params['cache'] ?? true;
+        $useCache = $params['cache'] ?? false;
         $cacheTtl = $params['cache_ttl'] ?? $this->config->get('ai.cache_ttl', 3600);
         $cacheKey = $this->generateCacheKey($params);
 
@@ -19,8 +19,9 @@ class OpenAI extends AI
             }
         }
 
+        $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.openai.endpoint');
         $result = $this->makeApiRequest(
-            $this->config->get('ai.providers.openai.endpoint'),
+            $endpoint,
             $this->prepareRequestBody($params), 
             $this->prepareHeaders(), 
             $this->config->get('ai.http_timeout')

--- a/src/Framework/Console/Views/Config/AiView.php
+++ b/src/Framework/Console/Views/Config/AiView.php
@@ -12,7 +12,7 @@ class AiView
 return [
     'ai' => [
         'driver' => get_env('AI_PROVIDER'), // openai, anthropic, mistral, groq
-        'cache_ttl' => 3600, // Cache responses for 1 hour by default
+        'cache_ttl' => 3600, // Cache TTL in seconds (when caching is enabled)
         'http_timeout' => 15, // 15 seconds HTTP timeout by default
         'temperature' => 0.7,
         'max_tokens' => 256,


### PR DESCRIPTION
- Changed default caching behavior from enabled to disabled across all AI providers (OpenAI, Anthropic, Mistral, Groq)
- Added support for overriding API endpoints via params['endpoint'] with fallback to config values
- Updated cache TTL comment to clarify it only applies when caching is explicitly enabled
- Standardized endpoint configuration handling across all AI provider classes