### PR TITLE
refactor: centralize caching logic for AI providers

### DIFF
--- a/src/Framework/AI/Providers/Mistral.php
+++ b/src/Framework/AI/Providers/Mistral.php
@@ -5,36 +5,21 @@ use Lightpack\AI\AI;
 
 class Mistral extends AI
 {
-    /**
-     * Generate a response from the Mistral API.
-     */
     public function generate(array $params): array
     {
-        $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
-        $useCache = $params['cache'] ?? false;
-        $cacheTtl = $params['cache_ttl'] ?? $this->config->get('ai.cache_ttl',);
-        $cacheKey = $this->generateCacheKey($params);
-
-        // Check cache first
-        if ($useCache && $this->cache->has($cacheKey)) {
-            return $this->cache->get($cacheKey);
-        }
-
-        $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.mistral.endpoint');
-        $result = $this->makeApiRequest(
-            $endpoint,
-            $this->prepareRequestBody($params),
-            $this->prepareHeaders(),
-            $this->config->get('ai.http_timeout')
-        );
-        $output = $this->parseOutput($result);
-
-        // Write to cache
-        if ($useCache) {
-            $this->cache->set($cacheKey, $output, $cacheTtl);
-        }
-
-        return $output;
+        return $this->executeWithCache($params, function() use ($params) {
+            $params['messages'] = $params['messages'] ?? [['role' => 'user', 'content' => $params['prompt'] ?? '']];
+            $endpoint = $params['endpoint'] ?? $this->config->get('ai.providers.mistral.endpoint');
+            
+            $result = $this->makeApiRequest(
+                $endpoint,
+                $this->prepareRequestBody($params),
+                $this->prepareHeaders(),
+                $this->config->get('ai.http_timeout')
+            );
+            
+            return $this->parseOutput($result);
+        });
     }
 
     /**


### PR DESCRIPTION
- Added executeWithCache() method in base AI class to handle common caching functionality
- Refactored all AI providers (OpenAI, Anthropic, Groq, Mistral) to use the new centralized caching method
- Simplified provider generate() methods by extracting duplicate cache handling code
- Standardized cache TTL fallback to 3600 seconds across all providers
- Added type hint for generate() method return type to ensure consistency