### PR TITLE
feat: add daily file logger with retention policy

### DIFF
--- a/src/Framework/Console/Views/Config/LogsView.php
+++ b/src/Framework/Console/Views/Config/LogsView.php
@@ -12,8 +12,9 @@ class LogsView
 return [
     'logs' => [
         'path' => DIR_STORAGE . '/logs',
-        'max_file_size' => 500 * 1024 * 1024, // 10mb
-        'max_log_files' => 10,
+        'max_file_size' => 10 * 1024 * 1024, // 10MB (used by 'file' driver)
+        'max_log_files' => 10,                // (used by 'file' driver)
+        'days_to_keep' => 7,                  // (used by 'daily' driver)
     ]
 ];
 PHP;

--- a/src/Framework/Logger/Drivers/DailyFileLogger.php
+++ b/src/Framework/Logger/Drivers/DailyFileLogger.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Lightpack\Logger\Drivers;
+
+use Lightpack\Logger\ILogger;
+
+class DailyFileLogger implements ILogger
+{
+    private $basePath;
+    private $daysToKeep;
+
+    public function __construct(string $basePath, int $daysToKeep = 7)
+    {
+        $this->basePath = rtrim($basePath, '/');
+        $this->daysToKeep = $daysToKeep;
+        
+        // Create directory if it doesn't exist
+        if (!is_dir($this->basePath)) {
+            mkdir($this->basePath, 0755, true);
+        }
+    }
+
+    public function log($level, $message, array $context = [])
+    {
+        $logEntry = $this->formatLogEntry($level, $message, $context);
+        $this->cleanupOldLogs();
+        $this->writeLog($logEntry);
+    }
+
+    private function formatLogEntry($level, $message, $context)
+    {
+        $level = strtoupper($level);
+        $timestamp = date('Y-m-d H:i:s');
+        $logEntry = str_repeat('-', 80) . PHP_EOL;
+        $logEntry .= "[$timestamp] $level: $message" . PHP_EOL;
+
+        if (!empty($context)) {
+            if (isset($context['stack_trace'])) {
+                $trace = $context['stack_trace'];
+                unset($context['stack_trace']);
+                $logEntry .= "File: {$trace['file']}:{$trace['line']}" . PHP_EOL;
+                $logEntry .= "Stack Trace:" . PHP_EOL . $trace['trace'] . PHP_EOL;
+            }
+            
+            if (!empty($context)) {
+                $logEntry .= "Context:" . PHP_EOL;
+                $logEntry .= json_encode($context, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+            }
+        }
+        
+        return $logEntry;
+    }
+
+    private function cleanupOldLogs(): void
+    {
+        $cutoffDate = date('Y-m-d', strtotime("-{$this->daysToKeep} days"));
+        $pattern = $this->basePath . '/lightpack-*.log';
+        
+        foreach (glob($pattern) as $file) {
+            // Extract date from filename using regex
+            if (preg_match('/lightpack-(\d{4}-\d{2}-\d{2})\.log$/', basename($file), $matches)) {
+                $fileDate = $matches[1];
+                
+                // Delete if older than cutoff date
+                if ($fileDate < $cutoffDate) {
+                    @unlink($file);
+                }
+            }
+        }
+    }
+
+    private function getCurrentLogFile(): string
+    {
+        return $this->basePath . '/lightpack-' . date('Y-m-d') . '.log';
+    }
+
+    private function writeLog($logEntry): void
+    {
+        file_put_contents($this->getCurrentLogFile(), $logEntry, FILE_APPEND | LOCK_EX);
+    }
+}

--- a/src/Framework/Providers/LogProvider.php
+++ b/src/Framework/Providers/LogProvider.php
@@ -5,6 +5,7 @@ namespace Lightpack\Providers;
 use Lightpack\Logger\Logger;
 use Lightpack\Logger\ILogger;
 use Lightpack\Logger\Drivers\FileLogger;
+use Lightpack\Logger\Drivers\DailyFileLogger;
 use Lightpack\Logger\Drivers\NullLogger;
 use Lightpack\Container\Container;
 
@@ -14,12 +15,20 @@ class LogProvider implements ProviderInterface
     {
         $container->register('logger', function ($container) {
             $logDriver = new NullLogger;
+            $driver = get_env('LOG_DRIVER', 'null');
 
-            if ('file' === get_env('LOG_DRIVER')) {
+            if ($driver === 'file') {
                 $logDriver = new FileLogger(
                     $container->get('config')->get('logs.path', DIR_STORAGE . '/logs') . '/lightpack.log',
                     $container->get('config')->get('logs.max_file_size', 10 * 1024 * 1024), // 10mb
                     $container->get('config')->get('logs.max_log_files', 10),
+                );
+            }
+
+            if ($driver === 'daily') {
+                $logDriver = new DailyFileLogger(
+                    $container->get('config')->get('logs.path', DIR_STORAGE . '/logs'),
+                    $container->get('config')->get('logs.days_to_keep', 7),
                 );
             }
 

--- a/tests/Logger/DailyFileLoggerTest.php
+++ b/tests/Logger/DailyFileLoggerTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+use Lightpack\Logger\Logger;
+use PHPUnit\Framework\TestCase;
+use Lightpack\Logger\Drivers\DailyFileLogger;
+
+final class DailyFileLoggerTest extends TestCase
+{
+    private $logDir;
+
+    public function setUp(): void
+    {
+        $this->logDir = __DIR__ . '/tmp';
+        mkdir($this->logDir);
+    }
+
+    public function tearDown(): void
+    {
+        array_map('unlink', glob($this->logDir . '/*'));
+        rmdir($this->logDir);
+    }
+
+    public function testCreatesLogFileWithTodaysDate(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Test message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $this->assertTrue(file_exists($expectedFile));
+    }
+
+    public function testWritesLogEntryToFile(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Test message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('INFO: Test message', $content);
+    }
+
+    public function testAppendsMultipleLogEntries(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('First message');
+        $logger->error('Second message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('INFO: First message', $content);
+        $this->assertStringContainsString('ERROR: Second message', $content);
+    }
+
+    public function testLogsWithContext(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->error('Database error', [
+            'host' => 'localhost',
+            'port' => 3306,
+        ]);
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('ERROR: Database error', $content);
+        $this->assertStringContainsString('Context:', $content);
+        $this->assertStringContainsString('localhost', $content);
+        $this->assertStringContainsString('3306', $content);
+    }
+
+    public function testLogsWithStackTrace(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->critical('Exception occurred', [
+            'stack_trace' => [
+                'file' => '/path/to/file.php',
+                'line' => 42,
+                'trace' => 'Stack trace here',
+            ],
+        ]);
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('CRITICAL: Exception occurred', $content);
+        $this->assertStringContainsString('File: /path/to/file.php:42', $content);
+        $this->assertStringContainsString('Stack Trace:', $content);
+        $this->assertStringContainsString('Stack trace here', $content);
+    }
+
+    public function testDeletesLogsOlderThanRetentionPeriod(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 3); // Keep 3 days
+        $logger = new Logger($dailyLogger);
+        
+        // Create old log files
+        $oldDate1 = date('Y-m-d', strtotime('-5 days'));
+        $oldDate2 = date('Y-m-d', strtotime('-4 days'));
+        $recentDate = date('Y-m-d', strtotime('-2 days'));
+        
+        touch($this->logDir . '/lightpack-' . $oldDate1 . '.log');
+        touch($this->logDir . '/lightpack-' . $oldDate2 . '.log');
+        touch($this->logDir . '/lightpack-' . $recentDate . '.log');
+        
+        // Trigger cleanup by logging
+        $logger->info('Test message');
+        
+        // Old files should be deleted
+        $this->assertFalse(file_exists($this->logDir . '/lightpack-' . $oldDate1 . '.log'));
+        $this->assertFalse(file_exists($this->logDir . '/lightpack-' . $oldDate2 . '.log'));
+        
+        // Recent file should still exist
+        $this->assertTrue(file_exists($this->logDir . '/lightpack-' . $recentDate . '.log'));
+        
+        // Today's file should exist
+        $this->assertTrue(file_exists($this->logDir . '/lightpack-' . date('Y-m-d') . '.log'));
+    }
+
+    public function testKeepsExactNumberOfDays(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        // Create log files for the last 10 days
+        for ($i = 10; $i >= 1; $i--) {
+            $date = date('Y-m-d', strtotime("-{$i} days"));
+            touch($this->logDir . '/lightpack-' . $date . '.log');
+        }
+        
+        // Trigger cleanup
+        $logger->info('Test message');
+        
+        // Should keep only last 7 days + today (8 files total)
+        $logFiles = glob($this->logDir . '/lightpack-*.log');
+        $this->assertCount(8, $logFiles);
+    }
+
+    public function testHandlesInvalidFileNamesGracefully(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        // Create files with invalid names
+        touch($this->logDir . '/lightpack-invalid.log');
+        touch($this->logDir . '/other-file.log');
+        touch($this->logDir . '/lightpack-2024-13-45.log'); // Invalid date
+        
+        // Should not throw exception
+        $logger->info('Test message');
+        
+        // Invalid files should not be deleted (only valid date patterns)
+        $this->assertTrue(file_exists($this->logDir . '/lightpack-invalid.log'));
+        $this->assertTrue(file_exists($this->logDir . '/other-file.log'));
+    }
+
+    public function testCreatesDirectoryIfNotExists(): void
+    {
+        $newLogDir = $this->logDir . '/nested/logs';
+        
+        $dailyLogger = new DailyFileLogger($newLogDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Test message');
+        
+        $this->assertTrue(is_dir($newLogDir));
+        $this->assertTrue(file_exists($newLogDir . '/lightpack-' . date('Y-m-d') . '.log'));
+        
+        // Cleanup
+        unlink($newLogDir . '/lightpack-' . date('Y-m-d') . '.log');
+        rmdir($newLogDir);
+        rmdir($this->logDir . '/nested');
+    }
+
+    public function testCanLogEmergency(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->emergency('System failure');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('EMERGENCY: System failure', $content);
+    }
+
+    public function testCanLogAlert(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->alert('Action required');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('ALERT: Action required', $content);
+    }
+
+    public function testCanLogCritical(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->critical('Critical condition');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('CRITICAL: Critical condition', $content);
+    }
+
+    public function testCanLogError(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->error('Error message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('ERROR: Error message', $content);
+    }
+
+    public function testCanLogWarning(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->warning('Warning message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('WARNING: Warning message', $content);
+    }
+
+    public function testCanLogNotice(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->notice('Notice message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('NOTICE: Notice message', $content);
+    }
+
+    public function testCanLogInfo(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Info message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('INFO: Info message', $content);
+    }
+
+    public function testCanLogDebug(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->debug('Debug message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        $this->assertStringContainsString('DEBUG: Debug message', $content);
+    }
+
+    public function testIncludesTimestampInLogEntry(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Test message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        // Should contain timestamp in format [YYYY-MM-DD HH:MM:SS]
+        $this->assertMatchesRegularExpression('/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]/', $content);
+    }
+
+    public function testIncludesSeparatorLines(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir, 7);
+        $logger = new Logger($dailyLogger);
+        
+        $logger->info('Test message');
+        
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $content = file_get_contents($expectedFile);
+        
+        // Should contain separator line (80 dashes)
+        $this->assertStringContainsString(str_repeat('-', 80), $content);
+    }
+
+    public function testDefaultRetentionIs7Days(): void
+    {
+        $dailyLogger = new DailyFileLogger($this->logDir);
+        $logger = new Logger($dailyLogger);
+        
+        // Create log files for the last 10 days
+        for ($i = 10; $i >= 1; $i--) {
+            $date = date('Y-m-d', strtotime("-{$i} days"));
+            touch($this->logDir . '/lightpack-' . $date . '.log');
+        }
+        
+        // Trigger cleanup
+        $logger->info('Test message');
+        
+        // Should keep only last 7 days + today (8 files total)
+        $logFiles = glob($this->logDir . '/lightpack-*.log');
+        $this->assertCount(8, $logFiles);
+    }
+}

--- a/tests/Logger/LogProviderTest.php
+++ b/tests/Logger/LogProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Lightpack\Container\Container;
+use Lightpack\Providers\LogProvider;
+use Lightpack\Logger\Logger;
+use Lightpack\Logger\Drivers\FileLogger;
+use Lightpack\Logger\Drivers\DailyFileLogger;
+use Lightpack\Logger\Drivers\NullLogger;
+
+final class LogProviderTest extends TestCase
+{
+    private $container;
+    private $logDir;
+
+    public function setUp(): void
+    {
+        $this->container = new Container();
+        $this->logDir = __DIR__ . '/tmp';
+        
+        if (!is_dir($this->logDir)) {
+            mkdir($this->logDir);
+        }
+        
+        // Mock config
+        $config = new class {
+            private $data = [];
+            
+            public function set($key, $value) {
+                $this->data[$key] = $value;
+            }
+            
+            public function get($key, $default = null) {
+                return $this->data[$key] ?? $default;
+            }
+        };
+        
+        $config->set('logs.path', __DIR__ . '/tmp');
+        $config->set('logs.max_file_size', 10 * 1024 * 1024);
+        $config->set('logs.max_log_files', 10);
+        $config->set('logs.days_to_keep', 7);
+        
+        $this->container->register('config', fn() => $config);
+    }
+
+    public function tearDown(): void
+    {
+        if (is_dir($this->logDir)) {
+            array_map('unlink', glob($this->logDir . '/*'));
+            rmdir($this->logDir);
+        }
+    }
+
+    public function testRegistersNullLoggerByDefault(): void
+    {
+        $_ENV['LOG_DRIVER'] = 'null';
+        
+        $provider = new LogProvider();
+        $provider->register($this->container);
+        
+        $logger = $this->container->get('logger');
+        
+        $this->assertInstanceOf(Logger::class, $logger);
+        
+        // Verify it uses NullLogger by checking no file is created
+        $logger->info('Test message');
+        $files = glob($this->logDir . '/*');
+        $this->assertEmpty($files);
+    }
+
+    public function testRegistersFileLogger(): void
+    {
+        $_ENV['LOG_DRIVER'] = 'file';
+        
+        $provider = new LogProvider();
+        $provider->register($this->container);
+        
+        $logger = $this->container->get('logger');
+        
+        $this->assertInstanceOf(Logger::class, $logger);
+        
+        // Verify it creates a file log
+        $logger->info('Test message');
+        $this->assertTrue(file_exists($this->logDir . '/lightpack.log'));
+    }
+
+    public function testRegistersDailyFileLogger(): void
+    {
+        $_ENV['LOG_DRIVER'] = 'daily';
+        
+        $provider = new LogProvider();
+        $provider->register($this->container);
+        
+        $logger = $this->container->get('logger');
+        
+        $this->assertInstanceOf(Logger::class, $logger);
+        
+        // Verify it creates a daily log file
+        $logger->info('Test message');
+        $expectedFile = $this->logDir . '/lightpack-' . date('Y-m-d') . '.log';
+        $this->assertTrue(file_exists($expectedFile));
+    }
+
+    public function testUsesConfigurationValues(): void
+    {
+        $_ENV['LOG_DRIVER'] = 'daily';
+        
+        // Update config with custom values
+        $config = $this->container->get('config');
+        $config->set('logs.days_to_keep', 14);
+        
+        $provider = new LogProvider();
+        $provider->register($this->container);
+        
+        $logger = $this->container->get('logger');
+        
+        // Log something to trigger cleanup with custom retention
+        $logger->info('Test message');
+        
+        // Verify the logger was created successfully
+        $this->assertInstanceOf(Logger::class, $logger);
+    }
+}


### PR DESCRIPTION
- Added new DailyFileLogger driver that creates daily log files with format lightpack-YYYY-MM-DD.log
- Implemented automatic cleanup of old log files based on configurable retention period (default 7 days)
- Added 'days_to_keep' config option in LogsView for daily logger retention setting
- Updated LogProvider to support 'daily' driver option alongside existing 'file' driver
- Added comprehensive test suite for DailyFileLogger covering file creation