### PR TITLE
feat: add automatic database creation prompt in migration command

### DIFF
--- a/src/Framework/Console/Commands/RunMigrationUp.php
+++ b/src/Framework/Console/Commands/RunMigrationUp.php
@@ -28,8 +28,11 @@ class RunMigrationUp implements ICommand
             exit;
         }
 
-        $migrator = new Migrator($this->getConnection());
+        // Ensure database exists before running migrations
+        $this->ensureDatabaseExists();
 
+        $migrator = new Migrator($this->getConnection());
+        
         $migrations = $migrator->run(DIR_ROOT . '/database/migrations');
         
         fputs(STDOUT, "\n");
@@ -73,5 +76,94 @@ class RunMigrationUp implements ICommand
         } 
 
         return true;
+    }
+
+    /**
+     * Ensure the database exists, create it if missing.
+     *
+     * @return void
+     */
+    private function ensureDatabaseExists(): void
+    {
+        $database = Env::get('DB_NAME');
+        
+        try {
+            // Try to connect with the database specified
+            $this->getConnection();
+        } catch (\Exception $e) {
+            // Check if the error is due to missing database
+            if ($this->isDatabaseMissingError($e)) {
+                $this->handleMissingDatabase($database);
+            } else {
+                // Re-throw if it's a different error
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Check if the exception is due to a missing database.
+     *
+     * @param \Exception $e
+     * @return bool
+     */
+    private function isDatabaseMissingError(\Exception $e): bool
+    {
+        $message = $e->getMessage();
+        
+        // MySQL error 1049: Unknown database
+        return str_contains($message, 'Unknown database') || 
+               str_contains($message, "SQLSTATE[HY000] [1049]");
+    }
+
+    /**
+     * Handle missing database by prompting to create it.
+     *
+     * @param string $database
+     * @return void
+     */
+    private function handleMissingDatabase(string $database): void
+    {
+        fputs(STDOUT, "\n");
+        fputs(STDOUT, "⚠ WARNING: The database '{$database}' does not exist on the 'mysql' connection.\n\n");
+        fputs(STDOUT, "Would you like to create it? [y/N]: ");
+        
+        $response = strtolower(trim(fgets(STDIN)));
+        
+        if ($response !== 'y') {
+            fputs(STDOUT, "\n✓ Operation cancelled. No database was created.\n\n");
+            exit;
+        }
+        
+        $this->createDatabase($database);
+        
+        fputs(STDOUT, "\n✓ Database '{$database}' created successfully.\n\n");
+    }
+
+    /**
+     * Create the database.
+     *
+     * @param string $database
+     * @return void
+     */
+    private function createDatabase(string $database): void
+    {
+        try {
+            // Connect without specifying a database
+            $connection = new Mysql([
+                'host'      => Env::get('DB_HOST'),
+                'port'      => Env::get('DB_PORT'),
+                'username'  => Env::get('DB_USER'),
+                'password'  => Env::get('DB_PSWD'),
+                'database'  => null, // No database specified
+                'options'   => [],
+            ]);
+            
+            // Create the database
+            $connection->query("CREATE DATABASE IF NOT EXISTS `{$database}` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        } catch (\Exception $e) {
+            fputs(STDOUT, "\n✗ Failed to create database: " . $e->getMessage() . "\n\n");
+            exit;
+        }
     }
 }

--- a/src/Framework/Database/Adapters/Mysql.php
+++ b/src/Framework/Database/Adapters/Mysql.php
@@ -8,7 +8,13 @@ class Mysql extends DB
 {
     public function __construct(array $args)
     {
-        $dsn = "mysql:host={$args['host']};port={$args['port']};dbname={$args['database']}";
+        // Support connecting without a database (for database creation)
+        $dsn = "mysql:host={$args['host']};port={$args['port']}";
+        
+        if (isset($args['database']) && $args['database'] !== null) {
+            $dsn .= ";dbname={$args['database']}";
+        }
+        
         parent::__construct($dsn, $args['username'], $args['password'], $args['options']);
     }
 }


### PR DESCRIPTION
- Added ensureDatabaseExists() check before running migrations
- Prompts user to create database if it doesn't exist (MySQL error 1049)
- Modified Mysql adapter to support connecting without database name for creation
- Creates database with utf8mb4_unicode_ci collation when user confirms
- Added helper methods for database missing error detection and creation flow