### PR TITLE
fix(schema): add context parameter to foreign key compilation

### DIFF
--- a/src/Framework/Database/Schema/Compilers/AddColumn.php
+++ b/src/Framework/Database/Schema/Compilers/AddColumn.php
@@ -12,14 +12,17 @@ class AddColumn
 
         $columns->context('add');
 
-        $sql = "ALTER TABLE {$table->getName()} ";
-        $sql .= $columns->compile();
+        $parts = [];
 
-        if ($constraints = $table->foreignKeys()->compile()) {
-            $sql .= ', ' . $constraints;
+        if ($columnSql = $columns->compile()) {
+            $parts[] = $columnSql;
         }
 
-        $sql .= ";";
+        if ($constraints = $table->foreignKeys()->compile('alter')) {
+            $parts[] = $constraints;
+        }
+
+        $sql = "ALTER TABLE {$table->getName()} " . implode(', ', $parts) . ";";
 
         return $sql;
     }

--- a/src/Framework/Database/Schema/Compilers/AlterTable.php
+++ b/src/Framework/Database/Schema/Compilers/AlterTable.php
@@ -2,8 +2,6 @@
 
 namespace Lightpack\Database\Schema\Compilers;
 
-use Lightpack\Database\Schema\ForeignKey;
-
 class AlterTable
 {
     public function compilePrimary(string $table, string|array $columns): string
@@ -85,17 +83,6 @@ class AlterTable
     public function compileDropSpatial(string $table, string $indexName): string
     {
         $sql = "ALTER TABLE {$table} DROP INDEX {$indexName}";
-
-        return $sql;
-    }
-
-    /**
-     * @todo: test if this works.
-     */
-    public function compileForeignKey(string $table, string $column, string $referenceTable, string $referenceColumn, ?string $constraintName = null): string
-    {
-        $sql = "ALTER TABLE {$table} ADD ";
-        $sql .= (new ForeignKey)->compile($column, $referenceTable, $referenceColumn, $constraintName);
 
         return $sql;
     }

--- a/src/Framework/Database/Schema/Compilers/ModifyColumn.php
+++ b/src/Framework/Database/Schema/Compilers/ModifyColumn.php
@@ -14,7 +14,7 @@ class ModifyColumn
         $sql = "ALTER TABLE {$table->getName()} ";
         $sql .= $columns->compile();
 
-        if ($constraints = $table->foreignKeys()->compile()) {
+        if ($constraints = $table->foreignKeys()->compile('alter')) {
             $sql .= ', ' . $constraints;
         }
 

--- a/src/Framework/Database/Schema/ForeignKeyCollection.php
+++ b/src/Framework/Database/Schema/ForeignKeyCollection.php
@@ -14,12 +14,13 @@ class ForeignKeyCollection
         $this->keys[] = $key;
     }
 
-    public function compile()
+    public function compile(string $context = 'create')
     {
         $constraints = [];
 
         foreach ($this->keys as $key) {
-            $constraints[] = $key->compile();
+            $prefix = $context === 'alter' ? 'ADD ' : '';
+            $constraints[] = $prefix . $key->compile();
         }
 
         return implode(', ', $constraints);

--- a/tests/Database/Schema/SchemaTest.php
+++ b/tests/Database/Schema/SchemaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lightpack\Container\Container;
 use Lightpack\Database\Schema\Schema;
 use Lightpack\Database\Schema\Table;
 use PHPUnit\Framework\TestCase;
@@ -12,6 +13,9 @@ final class SchemaTest extends TestCase
     /** @var \Lightpack\Database\Schema\Schema */
     private $schema;
 
+    /** @var \Lightpack\Database\DB */
+    private $db;
+
     public function setUp(): void
     {
         $config = require __DIR__ . '/../tmp/mysql.config.php';
@@ -19,6 +23,25 @@ final class SchemaTest extends TestCase
         $this->connection = new \Lightpack\Database\Adapters\Mysql($config);
 
         $this->schema = new Schema($this->connection);
+
+        // Configure container
+        $container = Container::getInstance();
+
+        $container->register('db', function () {
+            return $this->db;
+        });
+
+        $container->register('logger', function () {
+            return new class {
+                public function error($message, $context = [])
+                {
+                }
+
+                public function critical($message, $context = [])
+                {
+                }
+            };
+        });
     }
 
     public function tearDown(): void
@@ -618,5 +641,60 @@ final class SchemaTest extends TestCase
         // Assert type
         $column = $this->schema->inspectColumn('products', 'status');
         $this->assertEquals("enum('active','inactive','deleted')", $column['Type']);
+    }
+
+    public function testSchemaCanAddForeignKeyOnlyToExistingTable()
+    {
+        // Create categories table
+        $this->schema->createTable('categories', function (Table $table) {
+            $table->id();
+            $table->varchar('title', 125);
+        });
+
+        // Create products table with category_id column but NO foreign key
+        $this->schema->createTable('products', function (Table $table) {
+            $table->id();
+            $table->column('category_id')->type('bigint')->attribute('unsigned');
+        });
+
+        // Assert no FK yet
+        $this->assertEmpty($this->schema->inspectForeignKeys('products'));
+
+        // Add foreign key only (no new column) to the existing table
+        $this->schema->alterTable('products')->add(function (Table $table) {
+            $table->foreignKey('category_id')->references('id')->on('categories');
+        });
+
+        // Assert foreign key was added
+        $foreignKey = $this->schema->inspectForeignKey('products', 'products_ibfk_1');
+        $this->assertEquals('products_ibfk_1', $foreignKey['CONSTRAINT_NAME']);
+    }
+
+    public function testSchemaCanAddColumnAndForeignKeyToExistingTable()
+    {
+        // Create categories table
+        $this->schema->createTable('categories', function (Table $table) {
+            $table->id();
+            $table->varchar('title', 125);
+        });
+
+        // Create products table WITHOUT category_id column
+        $this->schema->createTable('products', function (Table $table) {
+            $table->id();
+            $table->varchar('title', 125);
+        });
+
+        // Add column and foreign key together to the existing table
+        $this->schema->alterTable('products')->add(function (Table $table) {
+            $table->column('category_id')->type('bigint')->attribute('unsigned');
+            $table->foreignKey('category_id')->references('id')->on('categories');
+        });
+
+        // Assert column was added
+        $this->assertContains('category_id', $this->schema->inspectColumns('products'));
+
+        // Assert foreign key was added
+        $foreignKey = $this->schema->inspectForeignKey('products', 'products_ibfk_1');
+        $this->assertEquals('products_ibfk_1', $foreignKey['CONSTRAINT_NAME']);
     }
 }


### PR DESCRIPTION
- AddColumn: refactor to use parts array and pass 'alter' context to foreignKeys()->compile()
- ModifyColumn: pass 'alter' context to foreignKeys()->compile()
- ForeignKeyCollection: add context parameter to compile() method, prefix with 'ADD ' when context is 'alter'
- AlterTable: remove unused compileForeignKey() method and ForeignKey import
- SchemaTest: add container setup with db and logger, add tests for adding